### PR TITLE
Deprecation of vscode app in DI

### DIFF
--- a/GitWorkflow/Readme.md
+++ b/GitWorkflow/Readme.md
@@ -1,3 +1,8 @@
+# DEPRECATED: Do not use this method for SAP Data Intelligence Git integration!
+# INSTEAD: Use the SAP Data Intelligence [Git Terminal](https://help.sap.com/docs/SAP_DATA_INTELLIGENCE/1c1341f6911f4da5a35b191b40b426c8/5d7d9e25afb642ed9f4b21f0c62f9871.html?locale=en-US&version=Cloud).
+
+----
+
 # Git Integration and CI/CD Process with SAP Data Intelligence
 
 In this project we describe a process to develop [SAP Data Intelligence (SAP DI)](https://www.sap.com/products/data-intelligence.html) solutions using Git and to build, test, and deploy them


### PR DESCRIPTION
Background info from Martin Hartig:
> For customers in DI:Cloud, the installation of this app was not possible since applications cannot be installed in the extension strategy. But on customer request, this lock could be switch off, e.g. for the purpose of installing the vscode app.
> ...
> With the availability of the [Git Terminal](https://jira.tools.sap/browse/DM00-6517) ,  the reason for installing applications (e.g. vscode-app) is not valid anymore.   
> I have advised the service infrastructure colleagues, not to unlock this pretection anymore (-> [here](https://wiki.one.int.sap/wiki/pages/viewpage.action?spaceKey=bddevops&title=Admin+Wikis#AdminWikis-DI:CInstallVSCodeapplicationonDIcluster-deprecated), maybe read protected). 
> This will block new vscode installation requests.